### PR TITLE
Added tab complete.

### DIFF
--- a/src/main/java/network/palace/show/ShowPlugin.java
+++ b/src/main/java/network/palace/show/ShowPlugin.java
@@ -6,6 +6,8 @@ import com.craftmend.openaudiomc.api.interfaces.AudioApi;
 import com.craftmend.openaudiomc.spigot.OpenAudioMcSpigot;
 import lombok.Getter;
 import network.palace.show.commands.*;
+import network.palace.show.commands.show.ShowTabComplete;
+import network.palace.show.commands.showgen.ShowGenTabComplete;
 import network.palace.show.generator.ShowGenerator;
 import network.palace.show.listeners.ChunkListener;
 import network.palace.show.listeners.PlayerInteract;
@@ -83,6 +85,8 @@ public class ShowPlugin extends JavaPlugin {
         openAudioMcSpigot = OpenAudioMcSpigot.getInstance();
         FileUtil.setupFiles();
         this.getCommand("show").setExecutor(new ShowCommand());
+        this.getCommand("show").setTabCompleter(new ShowTabComplete());
+
         this.getCommand("showdebug").setExecutor(new ShowDebugCommand());
 
         FileConfiguration config = this.getConfig();
@@ -90,6 +94,7 @@ public class ShowPlugin extends JavaPlugin {
         if (config.getString("github.token") != null) {
             githubToken = config.getString("github.token");
             this.getCommand("showgen").setExecutor(new ShowgenCommand());
+            this.getCommand("showgen").setTabCompleter(new ShowGenTabComplete());
             Bukkit.getConsoleSender().sendMessage(ChatColor.GREEN + "[Show] Showgen has been enabled in show!");
         } else {
             Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "[Show] Showgen will not be running in Show! To enable it, add a github token to the config!");

--- a/src/main/java/network/palace/show/commands/ShowCommand.java
+++ b/src/main/java/network/palace/show/commands/ShowCommand.java
@@ -21,10 +21,8 @@ public class ShowCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(ChatColor.GREEN + "Show Commands:");
-            sender.sendMessage(ChatColor.AQUA + "/show list " + ChatColor.GREEN + "- List all running shows");
-            sender.sendMessage(ChatColor.AQUA + "/show start [Show Name] " + ChatColor.GREEN + "- Start a show");
-            sender.sendMessage(ChatColor.AQUA + "/show stop [Show Name] " + ChatColor.GREEN + "- Stop a show");
+            sendHelpMsg(sender);
+            return true;
         } else {
             switch (args[0]) {
                 case "list":
@@ -32,8 +30,16 @@ public class ShowCommand implements CommandExecutor {
                     break;
                 case "start":
                     if (sender instanceof Player) {
+                        if (args.length < 2) {
+                            sender.sendMessage(ChatColor.RED + "/show start <name>");
+                            return true;
+                        }
                         new StartCommand().handle(sender, args[1], ((Player) sender).getWorld());
                     } else if (sender instanceof BlockCommandSender) {
+                        if (args.length < 2) {
+                            sender.sendMessage(ChatColor.RED + "/show start <name>");
+                            return true;
+                        }
                         new StartCommand().handle(sender, args[1], ((BlockCommandSender) sender).getBlock().getWorld());
                     } else {
                         sender.sendMessage(ChatColor.RED + "You cannot run this from the console!");
@@ -41,18 +47,38 @@ public class ShowCommand implements CommandExecutor {
                     break;
                 case "stop":
                     if (sender instanceof Player) {
+                        if (args.length < 2) {
+                            sender.sendMessage(ChatColor.RED + "/show stop <name>");
+                            return true;
+                        }
                         new StopCommand().handle(sender, args[1]);
                     } else if (sender instanceof CommandBlock) {
+                        if (args.length < 2) {
+                            sender.sendMessage(ChatColor.RED + "/show stop <name>");
+                            return true;
+                        }
                         new StopCommand().handle(sender, args[1]);
                     } else {
                         sender.sendMessage(ChatColor.RED + "You cannot run this from the console!");
                     }
                     break;
                 default:
+                    sendHelpMsg(sender);
                     break;
             }
         }
 
         return true;
+    }
+
+    /**
+     * Sends a help message to the player.
+     * @param sender Who to send it to.
+     */
+    private void sendHelpMsg(CommandSender sender) {
+        sender.sendMessage(ChatColor.GREEN + "Show Commands:");
+        sender.sendMessage(ChatColor.AQUA + "/show list " + ChatColor.GREEN + "- List all running shows");
+        sender.sendMessage(ChatColor.AQUA + "/show start [Show Name] " + ChatColor.GREEN + "- Start a show");
+        sender.sendMessage(ChatColor.AQUA + "/show stop [Show Name] " + ChatColor.GREEN + "- Stop a show");
     }
 }

--- a/src/main/java/network/palace/show/commands/ShowDebugCommand.java
+++ b/src/main/java/network/palace/show/commands/ShowDebugCommand.java
@@ -11,17 +11,20 @@ public class ShowDebugCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
-
-            if (!ShowPlugin.debugMap.containsKey(player.getDisplayName())) {
-                ShowPlugin.debugMap.put(player.getDisplayName(), true);
-                player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.GREEN + "Enabled");
-            } else {
-                ShowPlugin.debugMap.remove(player.getDisplayName());
-                player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.RED + "Disabled");
-            }
+        if (!(sender instanceof Player)) {
+            sender.sendMessage(ChatColor.RED + "Debug is always enabled for console!");
+            return true;
         }
-        return false;
+
+        Player player = (Player) sender;
+
+        if (!ShowPlugin.debugMap.containsKey(player.getDisplayName())) {
+            ShowPlugin.debugMap.put(player.getDisplayName(), true);
+            player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.GREEN + "Enabled");
+        } else {
+            ShowPlugin.debugMap.remove(player.getDisplayName());
+            player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.RED + "Disabled");
+        }
+        return true;
     }
 }

--- a/src/main/java/network/palace/show/commands/ShowDebugCommand.java
+++ b/src/main/java/network/palace/show/commands/ShowDebugCommand.java
@@ -11,20 +11,17 @@ public class ShowDebugCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) {
-            sender.sendMessage(ChatColor.RED + "Debug is always enabled for console!");
-            return true;
-        }
+        if (sender instanceof Player) {
+            Player player = (Player) sender;
 
-        Player player = (Player) sender;
-
-        if (!ShowPlugin.debugMap.containsKey(player.getDisplayName())) {
-            ShowPlugin.debugMap.put(player.getDisplayName(), true);
-            player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.GREEN + "Enabled");
-        } else {
-            ShowPlugin.debugMap.remove(player.getDisplayName());
-            player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.RED + "Disabled");
+            if (!ShowPlugin.debugMap.containsKey(player.getDisplayName())) {
+                ShowPlugin.debugMap.put(player.getDisplayName(), true);
+                player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.GREEN + "Enabled");
+            } else {
+                ShowPlugin.debugMap.remove(player.getDisplayName());
+                player.sendMessage(ChatColor.AQUA + "[ShowDebug] - " + ChatColor.RED + "Disabled");
+            }
         }
-        return true;
+        return false;
     }
 }

--- a/src/main/java/network/palace/show/commands/ShowgenCommand.java
+++ b/src/main/java/network/palace/show/commands/ShowgenCommand.java
@@ -17,10 +17,7 @@ public class ShowgenCommand implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (args.length == 0) {
-            sender.sendMessage(ChatColor.GREEN + "ShowGen Commands:");
-            sender.sendMessage(ChatColor.AQUA + "/showgen generate [action] [bottom/top] [delay per layer] [timestamp]" + ChatColor.GREEN + "- Generate blocks of show actions with one command");
-            sender.sendMessage(ChatColor.AQUA + "/showgen setcorner x,y,z" + ChatColor.GREEN + "- Set the location of the final north-west-bottom corner to help give real coordinate values");
-            sender.sendMessage(ChatColor.AQUA + "/showgen setinitialscene " + ChatColor.GREEN + "- Set the initial scene for a generator session");
+            sendHelpMsg(sender);
             return true;
         }
 
@@ -40,12 +37,20 @@ public class ShowgenCommand implements CommandExecutor {
                 new SetInitialCommand().handle(sender);
                 break;
             default:
-                sender.sendMessage(ChatColor.GREEN + "ShowGen Commands:");
-                sender.sendMessage(ChatColor.AQUA + "/showgen generate [action] [bottom/top] [delay per layer] [timestamp]" + ChatColor.GREEN + "- Generate blocks of show actions with one command");
-                sender.sendMessage(ChatColor.AQUA + "/showgen setcorner x,y,z" + ChatColor.GREEN + "- Set the location of the final north-west-bottom corner to help give real coordinate values");
-                sender.sendMessage(ChatColor.AQUA + "/showgen setinitialscene " + ChatColor.GREEN + "- Set the initial scene for a generator session");
+                sendHelpMsg(sender);
                 break;
         }
         return true;
+    }
+
+    /**
+     * Sends a help message to the player.
+     * @param sender Who to send it to.
+     */
+    private void sendHelpMsg(CommandSender sender) {
+        sender.sendMessage(ChatColor.GREEN + "ShowGen Commands:");
+        sender.sendMessage(ChatColor.AQUA + "/showgen generate [action] [bottom/top] [delay per layer] [timestamp]" + ChatColor.GREEN + "- Generate blocks of show actions with one command");
+        sender.sendMessage(ChatColor.AQUA + "/showgen setcorner x,y,z" + ChatColor.GREEN + "- Set the location of the final north-west-bottom corner to help give real coordinate values");
+        sender.sendMessage(ChatColor.AQUA + "/showgen setinitialscene " + ChatColor.GREEN + "- Set the initial scene for a generator session");
     }
 }

--- a/src/main/java/network/palace/show/commands/show/ShowTabComplete.java
+++ b/src/main/java/network/palace/show/commands/show/ShowTabComplete.java
@@ -1,11 +1,14 @@
 package network.palace.show.commands.show;
 
 import network.palace.show.ShowPlugin;
+import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +20,6 @@ public class ShowTabComplete implements TabCompleter {
 
     /show start <name>
     /show stop <name>
-    /show reload
     /show list
 
     /showgen generate <type> <time>
@@ -27,7 +29,7 @@ public class ShowTabComplete implements TabCompleter {
     /showdebug
      */
 
-    private static final String[] baseShowCmds = { "start", "stop", "list", "reload"};
+    private static final String[] baseShowCmds = { "start", "stop", "list" };
 
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
@@ -48,18 +50,42 @@ public class ShowTabComplete implements TabCompleter {
         // Handle subcommand args
         switch (args[0]) {
             case "start": {
-                // TODO add all not running shows
-                completions.add("Unsupported");
+                StringUtil.copyPartialMatches(args[1], Arrays.asList(getStoppedShows(((Player)sender).getWorld())), completions);
                 return completions;
             }
             case "stop": {
-                completions.addAll(ShowPlugin.getShows().keySet());
+                StringUtil.copyPartialMatches(args[1], ShowPlugin.getShows().keySet(), completions);
                 return completions;
             }
         }
 
         // Everything else without args
         return completions;
+    }
+
+    /**
+     * Gets all shows that arent currently running in the world.
+     * @param world What world
+     * @return The show names (minus .show)
+     */
+    private String[] getStoppedShows(World world) {
+        File f = new File("plugins/Show/shows/" + world.getName());
+        String[] fileNames = f.list();
+        if (fileNames == null) return new String[]{};
+
+        ArrayList<String> names = new ArrayList<>(List.of(fileNames));
+
+        // Strip ".show"
+        ArrayList<String> tempNames = new ArrayList<>();
+        for (String name : names) {
+            tempNames.add(name.replaceAll(".show", ""));
+        }
+        names = tempNames;
+
+        // Remove running shows
+        for (String name : ShowPlugin.getShows().keySet()) names.remove(name);
+
+        return names.toArray(new String[0]);
     }
 
 }

--- a/src/main/java/network/palace/show/commands/show/ShowTabComplete.java
+++ b/src/main/java/network/palace/show/commands/show/ShowTabComplete.java
@@ -1,0 +1,65 @@
+package network.palace.show.commands.show;
+
+import network.palace.show.ShowPlugin;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ShowTabComplete implements TabCompleter {
+
+    /*
+    Commands:
+
+    /show start <name>
+    /show stop <name>
+    /show reload
+    /show list
+
+    /showgen generate <type> <time>
+    /showgen setinitialscene
+    /showgen setcorner <x,y,z>
+
+    /showdebug
+     */
+
+    private static final String[] baseShowCmds = { "start", "stop", "list", "reload"};
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        final List<String> completions = new ArrayList<>();
+
+        // Return all subcommands if nothing has been typed
+        if (args.length == 0) {
+            completions.addAll(Arrays.asList(baseShowCmds));
+            return completions;
+        }
+
+        // Return applicable commands if started typing
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], Arrays.asList(baseShowCmds), completions);
+            return completions;
+        }
+
+        // Handle subcommand args
+        switch (args[0]) {
+            case "start": {
+                // TODO add all not running shows
+                completions.add("Unsupported");
+                return completions;
+            }
+            case "stop": {
+                completions.addAll(ShowPlugin.getShows().keySet());
+                return completions;
+            }
+        }
+
+        // Everything else without args
+        return completions;
+    }
+
+}

--- a/src/main/java/network/palace/show/commands/show/StartCommand.java
+++ b/src/main/java/network/palace/show/commands/show/StartCommand.java
@@ -20,10 +20,6 @@ public class StartCommand  {
             sender.sendMessage(ChatColor.RED + "Invalid world!");
             return;
         }
-        if (filename == null | filename.equals("")) {
-            sender.sendMessage(ChatColor.RED + "/show start <name>");
-            return;
-        }
         if (ShowPlugin.getShows().containsKey(filename)) {
             sender.sendMessage(ChatColor.RED + "----------------------------------------------");
             sender.sendMessage(ChatColor.RED + "That show is already running!");

--- a/src/main/java/network/palace/show/commands/show/StartCommand.java
+++ b/src/main/java/network/palace/show/commands/show/StartCommand.java
@@ -21,7 +21,7 @@ public class StartCommand  {
             return;
         }
         if (filename == null | filename.equals("")) {
-            sender.sendMessage(ChatColor.RED + "/show start [Show Name]");
+            sender.sendMessage(ChatColor.RED + "/show start <name>");
             return;
         }
         if (ShowPlugin.getShows().containsKey(filename)) {

--- a/src/main/java/network/palace/show/commands/show/StopCommand.java
+++ b/src/main/java/network/palace/show/commands/show/StopCommand.java
@@ -12,10 +12,6 @@ import org.bukkit.command.CommandSender;
 public class StopCommand {
 
     public void handle(CommandSender sender, String filename)  {
-        if (filename == null | filename.equals("")) {
-            sender.sendMessage(ChatColor.RED + "/show stop [Show Name]");
-            return;
-        }
         if (!ShowPlugin.getShows().containsKey(filename)) {
             sender.sendMessage(ChatColor.RED + "----------------------------------------------");
             sender.sendMessage(ChatColor.GOLD + filename + ChatColor.AQUA + " is not running!");

--- a/src/main/java/network/palace/show/commands/showgen/SetCornerCommand.java
+++ b/src/main/java/network/palace/show/commands/showgen/SetCornerCommand.java
@@ -13,22 +13,36 @@ public class SetCornerCommand {
     public void handle(CommandSender sender, String[] args) {
         Player player = (Player) sender;
         if (args.length < 2) {
-            player.sendMessage(ChatColor.RED + "/showgen setcorner x,y,z");
+            player.sendMessage(ChatColor.RED + "/showgen setcorner <x> <y> <z>");
             return;
         }
-        String[] locData = args[1].split(",");
-        if (locData.length < 3) {
-            player.sendMessage(ChatColor.RED + "/showgen setcorner x,y,z");
-            return;
+
+        String[] locData;
+
+        if (args[1].contains(",")) { // Legacy coordinate format - showgen setcorner x,y,z
+            locData = args[1].split(",");
+            if (locData.length < 3) {
+                player.sendMessage(ChatColor.RED + "/showgen setcorner <x> <y> <z>");
+                return;
+            }
+
+        } else { // New format - showgen setcorner x y z
+            if (args.length != 4) {
+                player.sendMessage(ChatColor.RED + "/showgen setcorner <x> <y> <z>");
+                return;
+            }
+
+            locData = new String[]{args[1], args[2], args[3]};
         }
+
         try {
-            int x = Integer.parseInt(locData[0]);
-            int y = Integer.parseInt(locData[1]);
-            int z = Integer.parseInt(locData[2]);
+            int x = (int) Double.parseDouble(locData[0]);
+            int y = (int) Double.parseDouble(locData[1]);
+            int z = (int) Double.parseDouble(locData[2]);
             World w = player.getWorld();
             GeneratorSession session = ShowPlugin.getShowGenerator().getOrCreateSession(player.getUniqueId());
             session.setCorner(new Location(w, x, y, z));
-            player.sendMessage(ChatColor.GREEN + "Set north-west-bottom corner to " + x + "," + y + "," + z + "!");
+            player.sendMessage(ChatColor.GREEN + "Set north-west-bottom corner to " + x + ", " + y + ", " + z + "!");
         } catch (NumberFormatException e) {
             player.sendMessage(ChatColor.RED + "Are you sure those are all numbers?");
         }

--- a/src/main/java/network/palace/show/commands/showgen/ShowGenTabComplete.java
+++ b/src/main/java/network/palace/show/commands/showgen/ShowGenTabComplete.java
@@ -53,9 +53,9 @@ public class ShowGenTabComplete implements TabCompleter {
 
                 // Params
                 if (args.length == 2) {
-                    completions.addAll(Arrays.asList(actionTypes));
-                } else if (args.length == 3) {
-                    completions.addAll(Arrays.asList(topOrBottom));
+                    StringUtil.copyPartialMatches(args[1], Arrays.asList(actionTypes), completions);
+                } else if (args.length == 3 && !args[2].equals("")) { // Tab complete when start typing, but not if empty
+                    StringUtil.copyPartialMatches(args[2], Arrays.asList(topOrBottom), completions);
                 }
 
                 return completions;
@@ -65,11 +65,11 @@ public class ShowGenTabComplete implements TabCompleter {
 
                 // Return players coords
                 if (args.length == 2) { // X
-                    completions.add(player.getLocation().getX()+",");
+                    completions.add(player.getLocation().getBlockX()+"");
                 } else if (args.length == 3) { // Y
-                    completions.add(player.getLocation().getY()+",");
+                    completions.add(player.getLocation().getBlockY()+"");
                 } else if (args.length == 4) { // Z
-                    completions.add(player.getLocation().getZ()+",");
+                    completions.add(player.getLocation().getBlockZ()+"");
                 }
 
                 return completions;

--- a/src/main/java/network/palace/show/commands/showgen/ShowGenTabComplete.java
+++ b/src/main/java/network/palace/show/commands/showgen/ShowGenTabComplete.java
@@ -1,0 +1,83 @@
+package network.palace.show.commands.showgen;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ShowGenTabComplete implements TabCompleter {
+
+    /*
+    Commands:
+
+    /show start <name>
+    /show stop <name>
+    /show reload
+    /show list
+
+    /showgen generate <type> [top/bottom] <layer-delay> <timestamp>
+    /showgen setinitialscene
+    /showgen setcorner <x,y,z>
+
+    /showdebug
+     */
+
+    private static final String[] baseShowGenCmds = { "generate", "setinitialscene", "setcorner" };
+    private static final String[] actionTypes = { "fakeblock" };
+    private static final String[] topOrBottom = { "top", "bottom" };
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        final List<String> completions = new ArrayList<>();
+
+        // Return all subcommands if nothing has been typed
+        if (args.length == 0) {
+            completions.addAll(Arrays.asList(baseShowGenCmds));
+            return completions;
+        }
+
+        // Return applicable commands if started typing
+        if (args.length == 1) {
+            StringUtil.copyPartialMatches(args[0], Arrays.asList(baseShowGenCmds), completions);
+            return completions;
+        }
+
+        // Handle subcommand args
+        switch (args[0]) {
+            case "generate": {
+
+                // Params
+                if (args.length == 2) {
+                    completions.addAll(Arrays.asList(actionTypes));
+                } else if (args.length == 3) {
+                    completions.addAll(Arrays.asList(topOrBottom));
+                }
+
+                return completions;
+            }
+            case "setcorner": {
+                Player player = (Player) sender;
+
+                // Return players coords
+                if (args.length == 2) { // X
+                    completions.add(player.getLocation().getX()+",");
+                } else if (args.length == 3) { // Y
+                    completions.add(player.getLocation().getY()+",");
+                } else if (args.length == 4) { // Z
+                    completions.add(player.getLocation().getZ()+",");
+                }
+
+                return completions;
+            }
+        }
+
+        // Everything else without args
+        return completions;
+    }
+
+}


### PR DESCRIPTION
**Show Subcommands:**
`/show list` list is tabcompleted
`/show start` start is tabcompleted, as well as all shows that arent currently running.
`/show stop` stop is tabcompleted, as well as all shows that are currently running.

**Showgen Subcommands:**
`/showgen setcorner` setcorner is tabcompleted as well as the players current coords.  Also, I added support to the command so you can use a standard coord format, rather than `x,y,z` you can now do `x y z`.  Old is still supported for backwards compatibility though.
`/showgen setinitialscene` setinitialscene is tabcompleted .
`/showgen generate` generate is tabcompleted, as well as `fakeblock` and `bottom`/`top`, but only if you start typing so both formats work.

**Other:**
I also fixed an out-of-bounds exception when not proving a show name, and any unknown/incomplete commands return a default help message.

My only concern is when generating the tab completions for show start, it has to actually check for files, so it could cause lag.  I tried to spam it and there were no issues, plus it's a staff-only command so I don't think it will be a problem.

This should be ready for review, but I will update you if I find any issues.  Thanks!